### PR TITLE
Add `include`, `exclude` options to webpack/nextjs plugin

### DIFF
--- a/packages/nextjs-plugin/src/index.ts
+++ b/packages/nextjs-plugin/src/index.ts
@@ -217,6 +217,9 @@ const withStyleX =
             },
             // Enforce nextjsMode to true
             nextjsMode: true,
+            // Pass through include/exclude options
+            include: pluginOptions?.include,
+            exclude: pluginOptions?.exclude,
             ...(extractCSS
               ? {
                   async transformCss(css, filePath) {

--- a/packages/webpack-plugin/src/types.ts
+++ b/packages/webpack-plugin/src/types.ts
@@ -52,6 +52,22 @@ export interface StyleXPluginOption extends Pick<StyleXWebpackLoaderOptions, 'tr
    * @default true
    */
   extractCSS?: boolean;
+
+  /**
+   * Patterns to include for StyleX transformation.
+   * By default, all files are processed. This option overrides `exclude` option.
+   *
+   * @example ['@myorg/design-system']
+   */
+  include?: (string | RegExp)[];
+
+  /**
+   * Patterns to exclude from StyleX transformation.
+   * By default, no files are excluded. This option is overridden by `include` option.
+   *
+   * @example [/node_modules/]
+   */
+  exclude?: (string | RegExp)[];
 }
 export type StyleXWebpackLoaderOptions = {
   stylexImports: StyleXOptions['importSources'];


### PR DESCRIPTION
## Description

- Add `include`, `exclude` options to webpack/nextjs plugin.
- For example you can use these options to exclude `node_modules` from compiling.


Related discussion: https://github.com/Dwlad90/stylex-swc-plugin/discussions/557