### PR TITLE
feat: add useLightningcss option (default: true) to enable Lightning CSS

### DIFF
--- a/packages/nextjs-plugin/README.md
+++ b/packages/nextjs-plugin/README.md
@@ -113,6 +113,8 @@ module.exports = stylexPlugin({
     });
     return result.css;
   },
+  // useLightningcss (default: true)
+  useLightningcss: false
 })({
   transpilePackages: ['@stylexjs/open-props'],
   // Optionally, add any other Next.js config below

--- a/packages/nextjs-plugin/src/index.ts
+++ b/packages/nextjs-plugin/src/index.ts
@@ -139,7 +139,7 @@ const withStyleX =
             ctx.dir,
             getSupportedBrowsers(ctx.dir, ctx.dev),
             undefined,
-            false
+            pluginOptions?.useLightningcss ?? true
           );
           return lazyPostCSSPromise;
         };

--- a/packages/webpack-plugin/src/types.ts
+++ b/packages/webpack-plugin/src/types.ts
@@ -68,6 +68,7 @@ export interface StyleXPluginOption extends Pick<StyleXWebpackLoaderOptions, 'tr
    * @example [/node_modules/]
    */
   exclude?: (string | RegExp)[];
+  useLightningcss?: boolean;
 }
 export type StyleXWebpackLoaderOptions = {
   stylexImports: StyleXOptions['importSources'];


### PR DESCRIPTION
## Description

Added useLightningcss option (default: true) to clean up postcss-preset-env warnings and improve performance. It's marked as experimental, but stylex's rollup plugin already [uses it by default ](https://stylexjs.com/blog/v0.8.0/#using-lightningcss-for-post-processing)so it should be stable enough.

## Additional Info

<img width="290" height="65" alt="image" src="https://github.com/user-attachments/assets/fcee65bf-7199-4471-a974-a8989e993a70" />

## Type of change

Please select options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
